### PR TITLE
fix: proper tournament timezone conversion and display using moment-t…

### DIFF
--- a/controllers/adminDashboard.js
+++ b/controllers/adminDashboard.js
@@ -1473,7 +1473,7 @@ function calculateTotalPrizePool(prizes, prizeType) {
       organizerEmail: t.organizer ? t.organizer.email : 'N/A',
       organizerLichess: t.organizer ? t.organizer.lichessUsername : 'N/A',
       startDate: t.startDate ? new Date(t.startDate).toLocaleDateString() : 'N/A',
-      startTime: t.startTime || 'N/A',
+      startTime: t.getDisplayTime ? t.getDisplayTime() : (t.startTime || 'N/A'),
       duration: t.duration || 'N/A',
       status: t.status || 'N/A',
       entryFee: t.entryFee || 0,

--- a/controllers/tournamentController.js
+++ b/controllers/tournamentController.js
@@ -79,6 +79,7 @@ exports.createTournament = asyncHandler(async (req, res) => {
     console.log('User timezone:', userTimezone);
     console.log('Start time received:', startTime);
     console.log('Start date received:', startDate);
+    console.log('Timezone conversion - Input time:', startTime, 'in timezone:', userTimezone);
 
 // Parse and validate duration
 const durationInHours = parseFloat(duration);
@@ -380,6 +381,12 @@ const addRegistrationInfo = (tournament) => {
   tournamentObj.startDateTime = tournament.getStartDateTime();
   tournamentObj.endDateTime = tournament.getEndDateTime();
   tournamentObj.currentStatus = tournament.currentStatus;
+  
+  // Add display time for proper timezone conversion
+  tournamentObj.displayTime = tournament.getDisplayTime();
+  
+  // Add user timezone time (for frontend display)
+  tournamentObj.userTimezoneTime = tournament.getUserTimezoneTime ? tournament.getUserTimezoneTime('Africa/Lagos') : tournament.startTime;
   
   // Add registration link
   tournamentObj.registrationLink = generateRegistrationLink(tournament._id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "express-session": "^1.18.1",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
+        "moment-timezone": "^0.6.0",
         "mongodb": "^6.13.0",
         "mongoose": "^8.12.1",
         "morgan": "^1.10.0",
@@ -1689,6 +1690,27 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.0.tgz",
+      "integrity": "sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mongodb": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express-session": "^1.18.1",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
+    "moment-timezone": "^0.6.0",
     "mongodb": "^6.13.0",
     "mongoose": "^8.12.1",
     "morgan": "^1.10.0",


### PR DESCRIPTION


### **Description**
This PR resolves issues with tournament time and status inconsistencies caused by improper timezone handling.  
**Key changes:**
- Integrated `moment-timezone` for robust timezone conversion.
- Fixed backend logic to store tournament times in UTC and convert to/from user timezones accurately.
- Added `displayTime` and `userTimezoneTime` fields to API responses for correct frontend display.
- Updated status calculation to always use UTC, ensuring consistent tournament status across all pages (home, explore, payout, admin).
- Improved debugging and logging for easier future maintenance.
- Updated frontend and admin dashboard to use the new timezone-aware fields.

**Benefits:**
- Tournament status and times are now consistent and accurate for all users, regardless of their timezone.
- Users always see tournament times in their local timezone.
- Fixes the issue where tournament status would differ between the payout page and the home/explore pages.

